### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-harness-bash-test.yml
+++ b/.github/workflows/pr-harness-bash-test.yml
@@ -1,5 +1,8 @@
 name: PR Harness Bash Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/joelbyford/BasicAuth/security/code-scanning/6](https://github.com/joelbyford/BasicAuth/security/code-scanning/6)

To fix the problem, explicitly declare a `permissions` block to limit the `GITHUB_TOKEN` to the least privilege needed. This workflow only needs to read repository contents (for `actions/checkout`) and does not interact with issues, pull requests, or other GitHub resources, so `contents: read` at the workflow or job level is sufficient and preserves existing behavior for these steps.

The best fix here is to add a root-level `permissions` block just below the `name` (or above `on:`) in `.github/workflows/pr-harness-bash-test.yml`. This will apply to all jobs in the workflow, including `harness-bash-test`, and will restrict the token to read-only repository content access. No additional imports or methods are needed, as this is a pure YAML configuration change. Concretely, in `.github/workflows/pr-harness-bash-test.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1, keeping indentation consistent with other top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
